### PR TITLE
fix: 调整文本参数优先级，优先使用默认文本而不是发送者用户名

### DIFF
--- a/main.py
+++ b/main.py
@@ -382,6 +382,10 @@ class MemePlugin(Star):
         # 遍历原始消息段落
         for seg in messages:
             await _process_segment(seg)
+            
+        # 调整文本参数优先级
+        if len(target_names) < min_texts and default_texts:
+            texts.extend(default_texts)
 
         # 从消息平台获取发送者的额外参数
         if not target_ids:
@@ -407,8 +411,6 @@ class MemePlugin(Star):
         # 确保文本数量在min_texts到max_texts之间(参数足够即可)
         if len(texts) < min_texts and target_names:
             texts.extend(target_names)
-        if len(texts) < min_texts and default_texts:
-            texts.extend(default_texts)
         texts = texts[:max_texts]
 
         return meme_images, texts, options


### PR DESCRIPTION
Adjust the text parameter priority to use the default text instead of the sender_name。

## Sourcery 总结

错误修复：
- 优先使用 `default_texts` 填充缺失的文本条目，而不是回退到发送者名称

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use default_texts first to fill missing text entries instead of fallback to sender names

</details>