### PR TITLE
Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ apt-get update && apt-get install -y libgl1 libglib2.0-0
       # 格式: - ./宿主机路径:容器内路径
       - /root/astrbot_data/meme_generator:/usr/local/lib/python3.11/site-packages/meme_generator
       可能会遇到报错:加载 astrbot_plugin_memelite 插件时出现问题，原因 libEGL.so.1: cannot open shared object file: No such file or directory。
-      需要在容器内执行 : apt-get update && apt-get install -y libegl1 libgl1 libglib2.0-0t64 ,然后重启当前容器,如果依然失败请手动补齐以来
-      文字丢失显示口:请执行 apt-get update && apt-get install -y fonts-noto-cjk fonts-wqy-zenhei fonts-wqy-microhei,之后执行:fc-cache -fv 从而刷新缓存 然后重启容器
+      需要在容器内执行 : apt-get update && apt-get install -y libegl1 libgl1 libglib2.0-0t64 ,然后重启当前容器,如果依然失败请手动补齐依赖
+      文字丢失显示口:请执行 apt-get update && apt-get install -y fonts-noto-cjk fonts-wqy-zenhei fonts-wqy-microhei,之后执行:fc-cache -fv 然后刷新缓存 然后重启容器
 
 ### Rust版安装教程（会复杂一点点）
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,15 @@ apt-get update && apt-get install -y libgl1 libglib2.0-0
     Linux: AstrBot/venv/lib/python3.10/site-packages/meme_generator
     MacOS: 没用过
     Windows: AstrBot\.venv\Lib\site-packages\meme_generato
-    Docker: 问问用Docker的人
+    Docker: /usr/local/lib/python3.11/site-packages/meme_generator
+### Docker安装注意
+    docker-compose添加一下路径
+    volumes:
+      # 格式: - ./宿主机路径:容器内路径
+      - /root/astrbot_data/meme_generator:/usr/local/lib/python3.11/site-packages/meme_generator
+      可能会遇到报错:加载 astrbot_plugin_memelite 插件时出现问题，原因 libEGL.so.1: cannot open shared object file: No such file or directory。
+      需要在容器内执行 : apt-get update && apt-get install -y libegl1 libgl1 libglib2.0-0t64 ,然后重启当前容器,如果依然失败请手动补齐以来
+      文字丢失显示口:请执行 apt-get update && apt-get install -y fonts-noto-cjk fonts-wqy-zenhei fonts-wqy-microhei,之后执行:fc-cache -fv 从而刷新缓存 然后重启容器
 
 ### Rust版安装教程（会复杂一点点）
 


### PR DESCRIPTION
新增了docker下的某些错误以为文件路径

## Summary by Sourcery

文档：
- 添加用于安装 `meme_generator` 的 Docker 路径，并记录在 Docker 部署中卷挂载配置、依赖安装以及字体设置相关内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add Docker path for meme_generator installation and document volume mounting configuration, dependency installation, and font setup for Docker deployments.

</details>