### PR TITLE
feat: 支持禁用容易触发打架的关键词，支持WebUI 自定义关键词别名映射

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -45,5 +45,11 @@
         "type": "list",
         "hint": "黑名单里的关键词会被屏蔽而无法触发meme",
         "default": []
+    },
+    "keyword_aliases": {
+        "description": "自定义触发关键词别名",
+        "type": "object",
+        "hint": "键为自定义触发词，值为原关键词。如 {\"rua\": \"摸\"} 则输入 'rua' 等价于触发 '摸'。可用来改名避免冲突",
+        "default": {}
     }
 }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -49,6 +49,9 @@
     "keyword_aliases": {
         "description": "自定义触发关键词别名",
         "type": "object",
+        "items": {
+            "type": "string"
+        },
         "hint": "键为自定义触发词，值为原关键词。如 {\"rua\": \"摸\"} 则输入 'rua' 等价于触发 '摸'。可用来改名避免冲突",
         "default": {}
     }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -48,11 +48,20 @@
     },
     "keyword_aliases": {
         "description": "自定义触发关键词别名",
-        "type": "object",
+        "type": "template_list",
+        "hint": "自定义触发词到原关键词的映射。alias=自定义触发词，original=原关键词。如 alias='rua', original='摸' 则输入 'rua' 等价于触发 '摸'",
         "items": {
-            "type": "string"
+            "alias": {
+                "description": "自定义触发词",
+                "type": "string",
+                "default": ""
+            },
+            "original": {
+                "description": "原关键词",
+                "type": "string",
+                "default": ""
+            }
         },
-        "hint": "键为自定义触发词，值为原关键词。如 {\"rua\": \"摸\"} 则输入 'rua' 等价于触发 '摸'。可用来改名避免冲突",
-        "default": {}
+        "default": []
     }
 }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -57,7 +57,7 @@
                 "default": ""
             },
             "original": {
-                "description": "原关键词",
+                "description": "原关键词（从 /meme列表 中挑选）",
                 "type": "string",
                 "default": ""
             }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -43,13 +43,13 @@
     "memes_disabled_list": {
         "description": "meme黑名单",
         "type": "list",
-        "hint": "黑名单里的关键词会被屏蔽而无法触发meme",
+        "hint": "黑名单里的关键词会被屏蔽而无法触发meme。发送 /meme列表 查看全部可用关键词",
         "default": []
     },
     "keyword_aliases": {
         "description": "自定义触发关键词别名",
         "type": "template_list",
-        "hint": "自定义触发词到原关键词的映射。alias=自定义触发词，original=原关键词。如 alias='rua', original='摸' 则输入 'rua' 等价于触发 '摸'",
+        "hint": "自定义触发词到原关键词的映射。alias=自定义触发词，original=原关键词。如 alias='rua', original='摸' 则输入 'rua' 等价于触发 '摸'。发送 /meme列表 查看全部可用关键词",
         "items": {
             "alias": {
                 "description": "自定义触发词",

--- a/core/meme.py
+++ b/core/meme.py
@@ -123,6 +123,9 @@ class MemeManager:
         self.meme_keywords = [
             keyword for meme in self.memes for keyword in self._get_keywords(meme)
         ]
+        self._load_aliases()
+
+    def _load_aliases(self):
         aliases: dict[str, str] = dict(self.conf.get("keyword_aliases", {}) or {})
         self._keyword_aliases = {}
         for alias, original in aliases.items():
@@ -132,6 +135,7 @@ class MemeManager:
     def _ensure_memes_loaded(self) -> bool:
         if not self.memes:
             self._load_memes()
+        self._load_aliases()
         return bool(self.memes)
 
     @staticmethod
@@ -191,9 +195,14 @@ class MemeManager:
 
         self._load_memes()
 
+    def _resolve_alias(self, word: str) -> str:
+        return self._keyword_aliases.get(word, word)
+
     def find_meme(self, keyword: str) -> Meme | None:
         if not self._ensure_memes_loaded():
             return None
+
+        keyword = self._resolve_alias(keyword)
 
         for meme in self.memes:
             keywords = self._get_keywords(meme)
@@ -214,7 +223,7 @@ class MemeManager:
         first_word = text.split()[0] if text.split() else ""
 
         if first_word in self._keyword_aliases:
-            return self._keyword_aliases[first_word]
+            return first_word
 
         if fuzzy_match:
             return next((keyword for keyword in self.meme_keywords if keyword in text), None)

--- a/core/meme.py
+++ b/core/meme.py
@@ -71,6 +71,7 @@ class MemeManager:
         self.collect = collect
         self.memes: list[Meme] = []
         self.meme_keywords: list[str] = []
+        self._keyword_aliases: dict[str, str] = {}
 
         self.render_meme_list_func: Any = None
         self.check_resources_func: Any = None
@@ -122,6 +123,11 @@ class MemeManager:
         self.meme_keywords = [
             keyword for meme in self.memes for keyword in self._get_keywords(meme)
         ]
+        aliases: dict[str, str] = dict(self.conf.get("keyword_aliases", {}) or {})
+        self._keyword_aliases = {}
+        for alias, original in aliases.items():
+            if original in self.meme_keywords:
+                self._keyword_aliases[alias] = original
 
     def _ensure_memes_loaded(self) -> bool:
         if not self.memes:
@@ -199,16 +205,20 @@ class MemeManager:
     def is_meme_keyword(self, meme_name: str) -> bool:
         if not self._ensure_memes_loaded():
             return False
-        return meme_name in self.meme_keywords
+        return meme_name in self.meme_keywords or meme_name in self._keyword_aliases
 
     def match_meme_keyword(self, text: str, fuzzy_match: bool) -> str | None:
         if not self._ensure_memes_loaded():
             return None
 
+        first_word = text.split()[0] if text.split() else ""
+
+        if first_word in self._keyword_aliases:
+            return self._keyword_aliases[first_word]
+
         if fuzzy_match:
             return next((keyword for keyword in self.meme_keywords if keyword in text), None)
 
-        first_word = text.split()[0] if text.split() else ""
         return next((keyword for keyword in self.meme_keywords if keyword == first_word), None)
 
     async def render_meme_list_image(self) -> bytes | None:

--- a/core/meme.py
+++ b/core/meme.py
@@ -126,11 +126,18 @@ class MemeManager:
         self._load_aliases()
 
     def _load_aliases(self):
-        aliases: dict[str, str] = dict(self.conf.get("keyword_aliases", {}) or {})
+        raw = self.conf.get("keyword_aliases", []) or []
         self._keyword_aliases = {}
-        for alias, original in aliases.items():
-            if original in self.meme_keywords:
-                self._keyword_aliases[alias] = original
+        if isinstance(raw, dict):
+            for alias, original in raw.items():
+                if original in self.meme_keywords:
+                    self._keyword_aliases[alias] = original
+        elif isinstance(raw, list):
+            for item in raw:
+                alias = item.get("alias", "") if isinstance(item, dict) else ""
+                original = item.get("original", "") if isinstance(item, dict) else ""
+                if alias and original in self.meme_keywords:
+                    self._keyword_aliases[alias] = original
 
     def _ensure_memes_loaded(self) -> bool:
         if not self.memes:

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ class MemePlugin(Star):
     ):
         """启用meme"""
         if not meme_name:
-            yield event.plain_result("未指定要禁用的meme")
+            yield event.plain_result("未指定要启用的meme")
             return
         if not self.manager.is_meme_keyword(meme_name):
             yield event.plain_result(f"meme: {meme_name} 不存在")
@@ -138,6 +138,7 @@ class MemePlugin(Star):
                 pass
 
         if image:
+            logger.info(f"[astrbot_plugin_memelite] 触发 meme: {keyword}")
             yield event.chain_result([Comp.Image.fromBytes(image)])  # type: ignore
 
     async def terminate(self):

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from astrbot.core import AstrBotConfig
 from astrbot.core.platform import AstrMessageEvent
 from astrbot.core.star.filter.event_message_type import EventMessageType
 
-from .core.meme import MemeManager
+from .core.meme import MEME_GENERATOR_AVAILABLE, MemeManager
 from .core.param import ParamsCollector
 from .utils import compress_image
 
@@ -27,10 +27,18 @@ class MemePlugin(Star):
 
     @filter.command("meme帮助", alias={"表情帮助", "meme菜单", "meme列表"})
     async def memes_help(self, event):
+        count = len(self.manager.meme_keywords)
+        aliases = self.manager._keyword_aliases
+        alias_count = len(aliases)
+        lines = [
+            f"可用关键词: {count} 个",
+        ]
+        if alias_count:
+            lines.append(f"自定义别名: {alias_count} 个")
+        lines.append("在 WebUI 插件配置中可将关键词加入黑名单，或自定义别名")
+        yield event.plain_result("\n".join(lines))
         if output := await self.manager.render_meme_list_image():
             yield event.chain_result([Comp.Image.fromBytes(output)])
-        else:
-            yield event.plain_result("meme列表图生成失败")
 
     @filter.command("meme详情", alias={"表情详情", "meme信息"})
     async def meme_details_show(


### PR DESCRIPTION
## 变更内容

### 1. Bug 修复
- `remove_supervisor` 错误消息文案：`"未指定要禁用的meme"` → `"未指定要启用的meme"`

### 2. 新功能：WebUI 自定义关键词别名映射
- `_conf_schema.json` 新增 `keyword_aliases` 配置项（`type: object`）
- 用户可在 WebUI 配置面板定义别名，如 `{"rua": "摸"}`，输入 `rua` 等价于触发 `摸`
- 别名与原关键词互相独立，可分别禁用/启用
- 别名映射每次访问实时重载，WebUI 改配置后立即生效，无需重载插件

### 3. 日志可追溯性
- 成功触发 meme 时输出 `[astrbot_plugin_memelite] 触发 meme: {keyword}`，便于多插件环境下溯源

## 涉及的适配器键
`aiocqhttp`

## Summary by Sourcery

添加对可通过 WebUI 配置的表情包关键词别名的支持，并改进表情包处理的可观测性。

新功能：
- 允许通过 `keyword_aliases` 设置配置表情包关键词别名映射，使替代触发词可以映射到现有表情包。
- 在匹配和解析表情包触发时透明地使用已配置的关键词别名，同时将别名视为可独立启用/禁用的目标。

错误修复：
- 更正 `remove_supervisor` 命令的错误消息，使其说明必须指定表情包名称用于启用，而不是用于禁用。

增强：
- 在表情包成功触发时记录一条标准化日志消息，以便在多插件环境中进行追踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for WebUI-configurable meme keyword aliases and improve meme handling observability.

New Features:
- Allow configuring meme keyword alias mappings via the `keyword_aliases` setting so alternative trigger words can map to existing memes.
- Support using configured keyword aliases transparently when matching and resolving meme triggers, while treating aliases as independent enable/disable targets.

Bug Fixes:
- Correct the `remove_supervisor` command error message to state that a meme name must be specified for enabling rather than disabling.

Enhancements:
- Log a standardized message when a meme is successfully triggered to aid tracing in multi-plugin environments.

</details>